### PR TITLE
feat: ignore array instead of singular ignore

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,16 +1,18 @@
 let originalHTML = document.documentElement.innerHTML;
 const currentURL = window.location.href;
 
-// Define the LinkedIn messaging URL prefix
-const linkedinMessagingURLPrefix = "https://www.linkedin.com/messaging/thread";
+// ignoredSites is a list of prefix URL's that the extension should be disabled on.
+const ignoredSites = [
+  "https://www.linkedin.com/messaging/thread",
+]
 
 // Set the initial state to enabled if it hasn’t been set already
 if (localStorage["extensionEnabled"] === undefined) {
   localStorage["extensionEnabled"] = "true";
 }
 
-// Check if the current URL starts with the LinkedIn messaging URL prefix
-if (currentURL.startsWith(linkedinMessagingURLPrefix)) {
+// If the current URL starts with any of the ignored sites, then the extension is disabled.
+if (ignoredSites.every((v) => !currentURL.startsWith(v))) {
   console.log("Extension is disabled on LinkedIn Messaging.");
 } else {
   function processTextNode(node) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -7,12 +7,12 @@ if (localStorage["extensionEnabled"] === undefined) {
 
 // ignoredSites is a mapping of site names to their URLs. If the current URL starts with
 // any of the ignored sites, then the extension is disabled.
-const ignoredSites = [
+const disabledSites = [
    "https://www.linkedin.com/messaging/thread",
 ]
-const isIgnoredSite = ignoredSites.some((site) => window.location.href.startsWith(site))
+const isDisabledSite = disabledSites.some((site) => window.location.href.startsWith(site))
 
-if (isIgnoredSite) {
+if (isDisabledSite) {
   console.log(`Extension is disabled on ${isIgnoredSite}`);
 } else {
   function processTextNode(node) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,19 +1,19 @@
 let originalHTML = document.documentElement.innerHTML;
-const currentURL = window.location.href;
-
-// ignoredSites is a list of prefix URL's that the extension should be disabled on.
-const ignoredSites = [
-  "https://www.linkedin.com/messaging/thread",
-]
 
 // Set the initial state to enabled if it hasn’t been set already
 if (localStorage["extensionEnabled"] === undefined) {
   localStorage["extensionEnabled"] = "true";
 }
 
-// If the current URL starts with any of the ignored sites, then the extension is disabled.
-if (ignoredSites.every((v) => !currentURL.startsWith(v))) {
-  console.log("Extension is disabled on LinkedIn Messaging.");
+// ignoredSites is a mapping of site names to their URLs. If the current URL starts with
+// any of the ignored sites, then the extension is disabled.
+const ignoredSites = [
+   "https://www.linkedin.com/messaging/thread",
+]
+const isIgnoredSite = ignoredSites.some((site) => window.location.href.startsWith(site))
+
+if (isIgnoredSite) {
+  console.log(`Extension is disabled on ${isIgnoredSite}`);
 } else {
   function processTextNode(node) {
     let content = node.textContent;

--- a/contentScript.js
+++ b/contentScript.js
@@ -5,15 +5,15 @@ if (localStorage["extensionEnabled"] === undefined) {
   localStorage["extensionEnabled"] = "true";
 }
 
-// ignoredSites is a mapping of site names to their URLs. If the current URL starts with
-// any of the ignored sites, then the extension is disabled.
+// disabledSites is a mapping of site names to their URLs. If the current URL starts with
+// any of the values, then the extension is disabled.
 const disabledSites = [
    "https://www.linkedin.com/messaging/thread",
 ]
 const isDisabledSite = disabledSites.some((site) => window.location.href.startsWith(site))
 
 if (isDisabledSite) {
-  console.log(`Extension is disabled on ${isIgnoredSite}`);
+  console.log(`Extension is disabled on ${isDisabledSite}`);
 } else {
   function processTextNode(node) {
     let content = node.textContent;


### PR DESCRIPTION
This changes the logic from ignoring just the linkedin messages prefix to a list of prefixes.

Right now, it might seem not that useful, but this could be expanded on if more sites this should not operate on _and_ if you add configuration to the user, you can dump their configuration inside the array.